### PR TITLE
Update to use new pyusb v1.0.0b2 API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,13 @@ setup(
     author='Philipp Adelt',
     author_email='autosort-github@philipp.adelt.net ',
     url='https://github.com/padelt/temper-python',
-    version='1.2.1',
+    version='1.2.2',
     description='Reads temperature from TEMPerV1 devices (USB 0c45:7401)',
     long_description=open('README.md').read(),
     packages=['temperusb'],
-    install_requires=['pyusb>=1.0.0b1'],
+    install_requires=[
+        'pyusb>=1.0.0b2',
+    ],
     entry_points={
         'console_scripts': [
             'temper-poll = temperusb.cli:main',

--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -193,7 +193,7 @@ class TemperDevice(object):
         """
         Read data from device.
         """
-        data = self._device.read(ENDPOINT, REQ_INT_LEN, interface=INTERFACE, timeout=TIMEOUT)
+        data = self._device.read(ENDPOINT, REQ_INT_LEN, timeout=TIMEOUT)
         LOGGER.debug('Read data: {0}'.format(data))
         return data
 


### PR DESCRIPTION
This PR makes temperusb compatible with changes made to the pyusb API in v1.0.0b2 as outlined in the [Release Notes](https://github.com/walac/pyusb/blob/master/ReleaseNotes.rst). Fixes #21.

_Note: While the pyusb 1.0.0b2 release notes claim to have removed the `interface` arg from `detach_kernel_driver()` this does not appear to be the case. So this update retains the interface arg to `detach_kernel_driver()` while removing it from `read()`._

@padelt: if you're happy to merge this I'll upload a temperusb 1.2.2 package to PyPI as usual.
