### PR TITLE
fix imports after moving temper module

### DIFF
--- a/temperusb/__init__.py
+++ b/temperusb/__init__.py
@@ -1,1 +1,1 @@
-from temper import TemperDevice, TemperHandler
+from .temper import TemperDevice, TemperHandler

--- a/temperusb/cli.py
+++ b/temperusb/cli.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 from __future__ import print_function
-from temper import TemperHandler
+from temperusb.temper import TemperHandler
 import getopt, sys, os.path
 
 def usage():

--- a/temperusb/snmp.py
+++ b/temperusb/snmp.py
@@ -12,7 +12,7 @@ import sys
 import syslog
 import threading
 import snmp_passpersist as snmp
-from temper import TemperHandler, TemperDevice
+from temperusb.temper import TemperHandler, TemperDevice
 
 ERROR_TEMPERATURE = 9999
 


### PR DESCRIPTION
After the temper module was moved into the temperusb package, the
imports in the modules were not updated to reflect the new location.