### PR TITLE
Add method to scale without using /etc/temper.conf

### DIFF
--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -89,29 +89,35 @@ class TemperDevice(object):
         LOGGER.debug('Found device | Bus:{0} Ports:{1}'.format(
             self._bus, self._ports))
 
-    def set_calibration_data(self):
+    def set_calibration_data(self, scale=None, offset=None):
         """
         Set device calibration data based on settings in /etc/temper.conf.
         """
-        self._scale = 1.0
-        self._offset = 0.0
-        try:
-            f = open('/etc/temper.conf', 'r')
-        except IOError:
-            f = None
-        if f:
-            lines = f.read().split('\n')
-            f.close()
-            for line in lines:
-                matches = re.match(CALIB_LINE_STR, line)
-                if matches:
-                    bus = int(matches.groups()[0])
-                    ports = matches.groups()[1]
-                    scale = float(matches.groups()[2])
-                    offset = float(matches.groups()[3])
-                    if ports == self._ports:
-                        self._scale = scale
-                        self._offset = offset
+        if scale is not None and offset is not None:
+            self._scale = scale
+            self._offset = offset
+        elif scale is None and offset is None:
+            self._scale = 1.0
+            self._offset = 0.0
+            try:
+                f = open('/etc/temper.conf', 'r')
+            except IOError:
+                f = None
+            if f:
+                lines = f.read().split('\n')
+                f.close()
+                for line in lines:
+                    matches = re.match(CALIB_LINE_STR, line)
+                    if matches:
+                        bus = int(matches.groups()[0])
+                        ports = matches.groups()[1]
+                        scale = float(matches.groups()[2])
+                        offset = float(matches.groups()[3])
+                        if ports == self._ports:
+                            self._scale = scale
+                            self._offset = offset
+        else:
+            raise RuntimeError("Must set both scale and offset, or neither")
 
     def get_ports(self):
         """


### PR DESCRIPTION
This avoids knowing all the USB bus details, and provides an easy way to
override scale and offset.