### PR TITLE
Use pyusb 1.0.0rc1; disable unneeded interaction; no more USBErrors f…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,14 @@ setup(
     author='Philipp Adelt',
     author_email='autosort-github@philipp.adelt.net ',
     url='https://github.com/padelt/temper-python',
-    version='1.2.4',
+    version='1.3.0b1',
     description='Reads temperature from TEMPerV1 devices (USB 0c45:7401)',
     long_description=open('README.md').read(),
     packages=['temperusb'],
     install_requires=[
-        'pyusb==1.0.0b1',
+        'pyusb>=1.0.0rc1',
     ],
+    dependency_links = ['git+https://github.com/walac/pyusb.git#egg=pyusb-1.0.0rc1'],
     entry_points={
         'console_scripts': [
             'temper-poll = temperusb.cli:main',


### PR DESCRIPTION
…or padelt; simplify temperature calculation

@amorphic @ps-jay @amorphic Care to test and report if this branch works for you? Please also add on which Hardware, kernel version and pyusb backend you tested.
Backend can be verified using `PYUSB_DEBUG=debug temper-poll` (look for the line with `using backend`).