### PR TITLE
Support for TEMPer v1.4

### DIFF
--- a/temperusb/cli.py
+++ b/temperusb/cli.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 from __future__ import print_function, absolute_import
 import argparse
+import logging
 
 from .temper import TemperHandler
 
@@ -35,6 +36,8 @@ def parse_args():
 def main():
     args = parse_args()
     quiet = args.celsius or args.fahrenheit
+
+    logging.basicConfig(level = logging.ERROR if quiet else logging.WARNING)
 
     th = TemperHandler()
     devs = th.get_devices()

--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -9,8 +9,6 @@
 # details.
 
 import usb
-import sys
-import struct
 import os
 import re
 import logging
@@ -33,7 +31,6 @@ COMMANDS = {
     'ini2': b'\x01\x86\xff\x01\x00\x00\x00\x00',
 }
 LOGGER = logging.getLogger(__name__)
-IS_PY2 = sys.version[0] == '2'
 
 
 def readattr(path, name):
@@ -265,12 +262,7 @@ class TemperDevice(object):
         # Interpret device response
         for sensor in _sensors:
             offset = (sensor + 1) * 2
-            if IS_PY2:
-                data_s = b"".join([chr(byte) for byte in data])
-            else:
-                data_s = data.tobytes()
-            value = (struct.unpack('>h', data_s[offset:(offset + 2)])[0])
-            celsius = value / 256.0
+            celsius = data[offset] + data[offset+1] / 256.0
             celsius = celsius * self._scale + self._offset
             results[sensor] = {
                 'ports': self.get_ports(),

--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -184,9 +184,13 @@ class TemperDevice(object):
                 #    timeout=TIMEOUT)
 
 
+            # Magic: Our TEMPerV1.4 likes to be asked twice.  When
+            # only asked once, it get's stuck on the next access and
+            # requires a reset.
+            self._control_transfer(COMMANDS['temp'])
+            self._interrupt_read()
+
             # Turns out a whole lot of that magic seems unnecessary.
-            #self._control_transfer(COMMANDS['temp'])
-            #self._interrupt_read()
             #self._control_transfer(COMMANDS['ini1'])
             #self._interrupt_read()
             #self._control_transfer(COMMANDS['ini2'])

--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -282,7 +282,7 @@ class TemperDevice(object):
         Send device a control request with standard parameters and <data> as
         payload.
         """
-        LOGGER.debug('Ctrl transfer: {0}'.format(data))
+        LOGGER.debug('Ctrl transfer: %r', data)
         self._device.ctrl_transfer(bmRequestType=0x21, bRequest=0x09,
             wValue=0x0200, wIndex=0x01, data_or_wLength=data, timeout=TIMEOUT)
 
@@ -291,7 +291,7 @@ class TemperDevice(object):
         Read data from device.
         """
         data = self._device.read(ENDPOINT, REQ_INT_LEN, timeout=TIMEOUT)
-        LOGGER.debug('Read data: {0}'.format(data))
+        LOGGER.debug('Read data: %r', data)
         return data
 
     def close(self):


### PR DESCRIPTION
I have several TEMPerV1.4. They worked for one request, but then stopped working until they were re-plugged or reset.

This is a series of commits adding support for the TEMPerV1.4 as experienced by me. It also fixes some unrelated bugs / cleanups, separated out into their own commits. The first step was to reset and re-try when necessary. Even so I discovered how to make resets unnecessary, I kept the reset-logic as it adds robustness when dealing with other TEMPer revisions or devices in weird states. Then I discovered that some of the "unnecessary" magic actually is necessary for TEMPerV1.4.

If you don't like the whole patch-set, cherry-pick whatever you like and/or tell me what to improve for it to get accepted.