### PR TITLE
Rewrite temper-poll script so uses argparse

### DIFF
--- a/temperusb/cli.py
+++ b/temperusb/cli.py
@@ -24,8 +24,11 @@ def parse_args():
                         default='1')
     args = parser.parse_args()
 
-    args.sensor_ids = list(range(args.sensor_count)) if args.sensor_ids == 'all' \
-        else [int(args.sensor_ids)]
+    if args.sensor_ids == 'all':
+        args.sensor_ids = range(args.sensor_count)
+    else:
+        args.sensor_ids = [int(args.sensor_ids)]
+
     return args
 
 

--- a/temperusb/cli.py
+++ b/temperusb/cli.py
@@ -1,102 +1,56 @@
 # encoding: utf-8
-from __future__ import print_function
-from temperusb.temper import TemperHandler
-import getopt, sys, os.path
+from __future__ import print_function, absolute_import
+import argparse
 
-def usage():
-    print("%s [-p] [-q] [-c|-f] [-s 0|1|all] [-S 1|2] [-h|--help]" % os.path.basename(sys.argv[0]))
-    print("  -q    quiet: only output temperature as a floating number. Usefull for external program parsing")
-    print("        this option requires the use of -c or -f")
-    print("  -c    with -q, outputs temperature in celcius degrees.")
-    print("  -f    with -q, outputs temperature in fahrenheit degrees.")
-    print("  -s    sensor ID 0, 1, or all, to utilize that sensor(s) on the device (multisensor devices only).  Default: 0")
-    print("  -S    specify the number of sensors on the device.  Default: 1")
+from .temper import TemperHandler
+
+
+def parse_args():
+    descr = "Temperature data from a TEMPer v1.2 sensor."
+
+    parser = argparse.ArgumentParser(description=descr)
+    parser.add_argument("-p", "--disp_ports", action='store_true',
+                        help="Display ports")
+    units = parser.add_mutually_exclusive_group(required=False)
+    units.add_argument("-c", "--celsius", action='store_true',
+                       help="Quiet: just degrees celcius as decimal")
+    units.add_argument("-f", "--fahrenheit", action='store_true',
+                       help="Quiet: just degrees fahrenheit as decimal")
+    parser.add_argument("-s", "--sensor_ids", choices=['0', '1', 'all'],
+                        help="IDs of sensors to use on the device " +
+                        "(multisensor devices only)", default='0')
+    parser.add_argument("-S", "--sensor_count", choices=[1, 2], type=int,
+                        help="Specify the number of sensors on the device",
+                        default='1')
+    args = parser.parse_args()
+
+    args.sensor_ids = list(range(args.sensor_count)) if args.sensor_ids == 'all' \
+        else [int(args.sensor_ids)]
+    return args
+
 
 def main():
-    try:
-        opts, args = getopt.getopt(sys.argv[1:], ":hpcfqs:S:", ["help"])
-    except getopt.GetoptError as err:
-        print(str(err))
-        usage()
-        sys.exit(2)
-    degree_unit = False
-    sensor_count = 1  # Default unless specified otherwise
-    sensor_id = [0,]  # Default to first sensor unless specified
-    disp_ports = False
-    quiet_output = False
-    for o, a in opts:
-        if o == "-p":
-            disp_ports = True
-        elif o == "-c":
-            degree_unit = 'c'
-        elif o == "-f":
-            degree_unit = 'f'
-        elif o == "-q":
-            quiet_output = True
-        elif o == "-s":
-            if a == "all":
-                sensor_id = "all"
-            else:
-                try:
-                    sensor_id = int(a)
-                    if not (sensor_id == 0 or sensor_id == 1):
-                        raise ValueError(
-                            "sensor_id should be 0 or 1, %d given" % sensor_id
-                            )
-                    # convert to list
-                    sensor_id = [sensor_id,]
-                except ValueError as err:
-                    print(str(err))
-                    usage()
-                    sys.exit(3)
-        elif o == "-S":
-            try:
-                sensor_count = int(a)
-                if not (sensor_count == 1 or sensor_count == 2):
-                    raise ValueError(
-                        "sensor_count should be 1 or 2, %d given" % sensor_count
-                        )
-            except ValueError as err:
-                print(str(err))
-                usage()
-                sys.exit(4)
-        elif o in ("-h", "--help"):
-            usage()
-            sys.exit()
-        else:
-            raise RuntimeError("Unhandled option '%s'" % o)
-
-    if quiet_output and not degree_unit:
-        print('You need to specify unit (-c of -f) when using -q option')
-        sys.exit(1)
-
-    # handle the sensor_id "all" option - convert to number of sensors
-    if sensor_id == "all":
-        sensor_id = range(0, sensor_count)
-
-    if not set(sensor_id).issubset(range(0, sensor_count)):
-        print('You specified a sensor_id (-s), without specifying -S with an appropriate number of sensors')
-        sys.exit(5)
+    args = parse_args()
+    quiet = args.celsius or args.fahrenheit
 
     th = TemperHandler()
     devs = th.get_devices()
-    readings = []
-    if not quiet_output:
+    if not quiet:
         print("Found %i devices" % len(devs))
 
+    readings = []
+
     for dev in devs:
-        dev.set_sensor_count(sensor_count)
-        readings.append(dev.get_temperatures(sensors=sensor_id))
+        dev.set_sensor_count(args.sensor_count)
+        readings.append(dev.get_temperatures(sensors=args.sensor_ids))
 
     for i, reading in enumerate(readings):
         output = ''
-        if quiet_output:
-            if degree_unit == 'c':
+        if quiet:
+            if args.celsius:
                 dict_key = 'temperature_c'
-            elif degree_unit == 'f':
+            elif args.fahrenheit:
                 dict_key = 'temperature_f'
-            else:
-                raise ValueError('degree_unit expected to be c or f, got %s' % degree_unit)
 
             for sensor in sorted(reading):
                 output += '%0.1f; ' % reading[sensor][dict_key]
@@ -105,7 +59,7 @@ def main():
             portinfo = ''
             tempinfo = ''
             for sensor in sorted(reading):
-                if disp_ports and portinfo == '':
+                if args.disp_ports and portinfo == '':
                     portinfo = " (bus %s - port %s)" % (reading['bus'],
                                                         reading['ports'])
                 tempinfo += '%0.1f°C %0.1f°F; ' % (
@@ -114,12 +68,9 @@ def main():
                 )
             tempinfo = tempinfo[0:len(output) - 2]
 
-            output = 'Device #%i%s: %s' % (
-                i,
-                portinfo,
-                tempinfo,
-            )
+            output = 'Device #%i%s: %s' % (i, portinfo, tempinfo)
         print(output)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
If `argparse` is used rather than `getopt` then the script is shorter and simpler.

NB I've removed the `-q` (quiet) option as it's implied by `-f` or `-c`.  Also, now `argparse` will only accept `-f` or `-c` but not both, which matches the logic later on in the script.