### PR TITLE
Add a table to README for "supported" devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,7 @@ via SNMP.
 | `0c45:7401 Microdia`                           | `RDing TEMPerV1.2`       | First supported device  |
 | `0c45:7401 Microdia TEMPer Temperature Sensor` | `RDing TEMPer2_M12_V1.3` | Two sensor device       |
 | `0c45:7401 Microdia`                           | `RDing TEMPer1F_V1.3`    | Single external sensor, but better precision is possible by using "sensor 2" |
-
-### Future support likely
-
-| USB ID                                         | Name Reported            | Notes                   |
-| ---------------------------------------------- | ------------------------ | ----------------------- |
-| `0c45:7401 Microdia`                           | `RDing TEMPerV1.4`       | See PR #43              |
+| `0c45:7401 Microdia`                           | `RDing TEMPerV1.4`       |                         |
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,23 @@ a USB ID like this: `0c45:7401 Microdia`
 My device came from [M-Ware ID7747](http://www.m-ware.de/m-ware-usb-thermometer-40--120-c-emailbenachrichtigung-id7747/a-7747/)
 and also reports itself as 'RDing TEMPerV1.2'.
 
-The code also works for devices reporting as 'RDing TEMPer1F_V1.3'.  These devices seem to only support temperature readings from the remote probe, where as the TEMPerV1.2 can read from the internal device, and the external probe.
-
 Also provides a passpersist-module for NetSNMP (as found in the `snmpd`
 packages of Debian and Ubuntu) to present the temperature of 1-3 USB devices
 via SNMP.
+
+### Reported working devices
+
+| USB ID                                         | Name Reported            | Notes                   |
+| ---------------------------------------------- | ------------------------ | ----------------------- |
+| `0c45:7401 Microdia`                           | `RDing TEMPerV1.2`       | First supported device  |
+| `0c45:7401 Microdia TEMPer Temperature Sensor` | `RDing TEMPer2_M12_V1.3` | Two sensor device       |
+| `0c45:7401 Microdia`                           | `RDing TEMPer1F_V1.3`    | Single external sensor, but better precision is possible by using "sensor 2" |
+
+### Future support likely
+
+| USB ID                                         | Name Reported            | Notes                   |
+| ---------------------------------------------- | ------------------------ | ----------------------- |
+| `0c45:7401 Microdia`                           | `RDing TEMPerV1.4`       | See PR #43              |
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -284,3 +284,4 @@ The `snmp_passpersist` mode is Python 2 only because the upstream package is not
 * PyPI package work and rewrite to `libusb1` by James Stewart (@amorphic on Github)
 * Reduced kernel messages and support multiple sensors by Philip Jay (@ps-jay on Github)
 * Python 3 compatibility and rewrite of cli.py to use argparse by Will Furnass (@willfurnass on Github)
+* TEMPerV1.4 support by Christian von Roques (@roques on Github)


### PR DESCRIPTION
I didn't realise that I had been using a `TEMPer2_M12_V1.3` rather than a `TEMPerV1.2`.
I thought I'd rework the tested/supported devices into a table.