### PR TITLE
Auto-detect sensor_count and offset - better supports TEMPer1F_V1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,6 @@ The `snmp_passpersist` mode is Python 2 only because the upstream package is not
 * Calibration code by Joji Monma (@GM3D on Github)
 * Munin plugin by Alexander Schier (@allo- on Github)
 * PyPI package work and rewrite to `libusb1` by James Stewart (@amorphic on Github)
-* Reduced kernel messages and support multiple sensors by Philip Jay (@ps-jay on Github)
+* Reduced kernel messages, support multiple sensors, and support TEMPer1F_V1.3 by Philip Jay (@ps-jay on Github)
 * Python 3 compatibility and rewrite of cli.py to use argparse by Will Furnass (@willfurnass on Github)
 * TEMPerV1.4 support by Christian von Roques (@roques on Github)

--- a/temperusb/cli.py
+++ b/temperusb/cli.py
@@ -20,15 +20,9 @@ def parse_args():
     parser.add_argument("-s", "--sensor_ids", choices=['0', '1', 'all'],
                         help="IDs of sensors to use on the device " +
                         "(multisensor devices only)", default='0')
-    parser.add_argument("-S", "--sensor_count", choices=[1, 2], type=int,
-                        help="Specify the number of sensors on the device",
-                        default='1')
+    parser.add_argument("-S", "--sensor_count", type=int,
+                        help="Override auto-detected number of sensors on the device")
     args = parser.parse_args()
-
-    if args.sensor_ids == 'all':
-        args.sensor_ids = range(args.sensor_count)
-    else:
-        args.sensor_ids = [int(args.sensor_ids)]
 
     return args
 
@@ -47,7 +41,15 @@ def main():
     readings = []
 
     for dev in devs:
-        dev.set_sensor_count(args.sensor_count)
+        if args.sensor_count is not None:
+            # Override auto-detection from args
+            dev.set_sensor_count(int(args.sensor_count))
+
+        if args.sensor_ids == 'all':
+            args.sensor_ids = range(dev.get_sensor_count())
+        else:
+            args.sensor_ids = [int(args.sensor_ids)]
+
         readings.append(dev.get_temperatures(sensors=args.sensor_ids))
 
     for i, reading in enumerate(readings):

--- a/temperusb/cli.py
+++ b/temperusb/cli.py
@@ -46,11 +46,11 @@ def main():
             dev.set_sensor_count(int(args.sensor_count))
 
         if args.sensor_ids == 'all':
-            args.sensor_ids = range(dev.get_sensor_count())
+            sensors = range(dev.get_sensor_count())
         else:
-            args.sensor_ids = [int(args.sensor_ids)]
+            sensors = [int(args.sensor_ids)]
 
-        readings.append(dev.get_temperatures(sensors=args.sensor_ids))
+        readings.append(dev.get_temperatures(sensors=sensors))
 
     for i, reading in enumerate(readings):
         output = ''


### PR DESCRIPTION
`TEMPer1F_V1.3` is different to the other devices we've supported in code so far.
It has only one sensor, and the reading is available at offset 4.

I've introduced two new functions:
- ```lookup_offset(sensor)```
- ```lookup_sensor_count()```

These handle the differences between `TEMPer1F_V1.3` and the rest.
We can add to these functions over time, as we find more devices out there.

I've tested against my two devices, and with Python 2.6, 2.7 and 3.4.
But don't take my word for it.  Please test yourselves : )