### PR TITLE
Clarify installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Under Debian/Ubuntu, treat yourself to some package goodness:
 
 # Installation and usage
 
-After you run
+Clone the repository, cd into its top-level directory, and run
 
     sudo python setup.py install
 


### PR DESCRIPTION
If you're reading the README.md on the Web or from the Python package description, it is unclear what directory you need to be in to run the package setup.