### PR TITLE
TEMPerHUM device

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ via SNMP.
 
 ### Reported working devices
 
-| USB ID                                         | Name Reported            | Notes                   |
-| ---------------------------------------------- | ------------------------ | ----------------------- |
-| `0c45:7401 Microdia`                           | `RDing TEMPerV1.2`       | First supported device  |
-| `0c45:7401 Microdia TEMPer Temperature Sensor` | `RDing TEMPer2_M12_V1.3` | Two sensor device       |
-| `0c45:7401 Microdia`                           | `RDing TEMPer1F_V1.3`    | Single external sensor, but better precision is possible by using "sensor 2" |
-| `0c45:7401 Microdia`                           | `RDing TEMPerV1.4`       |                         |
+| USB ID                                                       | Name Reported            | Notes                   |
+| ------------------------------------------------------------ | ------------------------ | ----------------------- |
+| `0c45:7401 Microdia`                                         | `RDing TEMPerV1.2`       | First supported device  |
+| `0c45:7401 Microdia TEMPer Temperature Sensor`               | `RDing TEMPer2_M12_V1.3` | Two sensor device       |
+| `0c45:7401 Microdia`                                         | `RDing TEMPer1F_V1.3`    | Single external sensor, but better precision is possible by using "sensor 2" |
+| `0c45:7401 Microdia`                                         | `RDing TEMPerV1.4`       |                         |
+| `0c45:7402 Microdia TEMPerHUM Temperature & Humidity Sensor` | `RDing TEMPer1F_H1_V1.4` | Single sensor which reports both temperature and relative-humidity |
 
 # Requirements
 

--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -15,6 +15,7 @@ import logging
 
 VIDPIDS = [
     (0x0c45, 0x7401),
+    (0x0c45, 0x7402),
 ]
 REQ_INT_LEN = 8
 ENDPOINT = 0x82
@@ -149,7 +150,8 @@ class TemperDevice(object):
         """
         Lookup the number of sensors on the device by product name.
         """
-        if self._device.product == 'TEMPer1F_V1.3':
+        if (self._device.product == 'TEMPer1F_V1.3') or \
+            (self._device.product == 'TEMPer1F_H1_V1.4'):
             return 1
 
         # All others are two - if not the case, contribute here: https://github.com/padelt/temper-python/issues


### PR DESCRIPTION
Add support for the TEMPerHUM USB device ID's.
Whilst the device supports both temperature (offset 2) and relative humidity (offset 4), this change doesn't add support for reading the relative humidity (as that's likely to require a bit more re-work to the structure of the code).