### PR TITLE
fixed format string error in the munin plugin

### DIFF
--- a/etc/munin-temperature
+++ b/etc/munin-temperature
@@ -37,7 +37,7 @@ def config():
     for device in handler.get_devices():
         port = device.get_ports()
         port_name = str(port).replace('.', '_')
-        print "temp_" + port_name + ".label Port {0:s} Temperature".format(port)            
+        print "temp_" + port_name + ".label Port {0:s} Temperature".format(str(port))
 
 
 def fetch():


### PR DESCRIPTION
On my system, the current library has ports ``2`` and ``3`` (i do not know why no ``1``), which are integer.
This means either the formatstring must be ``{0:d}``, or port should be casted to string. As the port before used to be in the format "x.y.z" of the usb port layout, i did the string cast here, because i am not sure if it now always is an integer or not.

If you changed the id generation, it would further be important for the graphs, that the ids don't change over reboots / unplugging and pluggin in again.