### PR TITLE
Detect and correct uint8 underflow in temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,3 +285,4 @@ The `snmp_passpersist` mode is Python 2 only because the upstream package is not
 * Reduced kernel messages, support multiple sensors, and support TEMPer1F_V1.3 by Philip Jay (@ps-jay on Github)
 * Python 3 compatibility and rewrite of cli.py to use argparse by Will Furnass (@willfurnass on Github)
 * TEMPerV1.4 support by Christian von Roques (@roques on Github)
+* Integer underflow on negative temperatures fixed by Zac Hatfield-Dodds (@Zac-HD on Github)

--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -305,6 +305,10 @@ class TemperDevice(object):
         for sensor in _sensors:
             offset = self.lookup_offset(sensor)
             celsius = data[offset] + data[offset+1] / 256.0
+            if celsius > 180:
+                # Operating range is -40C to +120C; this is a uint8 underflow
+                # The threshold gives a representatable range of -75 to +180C
+                celsius -= 256.0
             celsius = celsius * self._scale + self._offset
             results[sensor] = {
                 'ports': self.get_ports(),


### PR DESCRIPTION
Negative actual temperatures would wrap to 256C, which is well outside the operating range of the device.  This is a dead-simple fix, but a quick patch release would be appreciated to close home-assistant/home-assistant#4896.