### PR TITLE
parse readme as utf-8 instead of ascii

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url='https://github.com/padelt/temper-python',
     version='1.5.3',
     description='Reads temperature from TEMPerV1 devices (USB 0c45:7401)',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     packages=['temperusb'],
     install_requires=[
         'pyusb>=1.0.0rc1',


### PR DESCRIPTION
The readme contains some UTF-8 symbols (ie: a degree symbol). When
generating long_description in setup.py, this was producing a
UnicodeDecodeError and erroring out.

Signed-off-by: Nicholas Sielicki <sielicki@yandex.com>