### PR TITLE
Add support for TEMPer2_V3.7

### DIFF
--- a/etc/99-tempsensor.rules
+++ b/etc/99-tempsensor.rules
@@ -1,2 +1,3 @@
 SUBSYSTEMS=="usb", ACTION=="add", ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="7401", MODE="666"
 SUBSYSTEMS=="usb", ACTION=="add", ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="7402", MODE="666"
+SUBSYSTEMS=="usb", ACTION=="add", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="e025", MODE="666"

--- a/temperusb/device_library.py
+++ b/temperusb/device_library.py
@@ -84,6 +84,11 @@ DEVICE_LIBRARY = {
         hum_sens_offsets=None,
         type=TemperType.FM75,
     ),
+    "TEMPer2_V3.7": TemperConfig(
+        temp_sens_offsets=[2, 10],
+        hum_sens_offsets=None,
+        type=TemperType.FM75,
+    ),
     "TEMPer2V1.4": TemperConfig(
         temp_sens_offsets=[2],
         hum_sens_offsets=None,

--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -19,6 +19,7 @@ from .device_library import DEVICE_LIBRARY, TemperType, TemperConfig
 VIDPIDS = [
     (0x0c45, 0x7401),
     (0x0c45, 0x7402),
+    (0x1a86, 0xe025),
 ]
 REQ_INT_LEN = 8
 ENDPOINT = 0x82


### PR DESCRIPTION
Further to issue #129 this adds experimental support for a new two channel temperature sensor.

I have not been able to test this device because I don't have it.

Please can someone verify it works by cloning the repository, checking out this branch, and trying it it using `python3 -m temperusb.cli`?

Based on info found here:
https://github.com/ccwienk/temper/commit/0178978cccd8e5ee14d67207e91c8cf78196e1d3

