### PR TITLE
Drop old python <3.7, add 3.11 to CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Some old python versions don't seem to be supported any more in the available test environments.

This PR adds testing within 3.11, and removes automatic testing <3.7.

Note that this change does not prevent users from using the library with python <3.7, it just changes what is automatically tested.
