### PR TITLE
feat(TemperDevice): add get_product function

### DIFF
--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -194,6 +194,12 @@ class TemperDevice(object):
 
         self._sensor_count = int(count)
 
+    def get_product(self):
+        """
+        Get device product name.
+        """
+        return self._device.product
+
     def get_ports(self):
         """
         Get device USB ports.


### PR DESCRIPTION
As the title says, this adds a tiny function, to get the product name of the used device.

```python
devices = temperusb.TemperHandler().get_devices()

for device_id, device in enumerate(devices):
    print(device.get_temperature(), device.get_product())
```

```bash
# python3 test.py
27.0625 TEMPerV1.4
```