### PR TITLE
Support python 3.13, drop 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ as seen on [Google+](https://plus.google.com/105569853186899442987/posts/N9T7xAj
 
 # Compatibility with Python versions
 
-This should work on Python 3.7 and above. It was tested with Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12.
+This should work on Python 3.8 and above. It was tested with Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13.
 
 # Authors
 


### PR DESCRIPTION
Add support for new python version 3.13 and remove stated support for 3.7 since the test environment no longer supports this.

In theory 3.7 (and possibly lower) will work, but this can no longer be guaranteed by the CI tests.